### PR TITLE
Show Instagram icon and toast message

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,6 @@
   }
      .hero-image {
     max-width: 100%;           /* ocupa toda a largura */
-    aspect-ratio: 16 / 9;      /* muda proporção para 16:9, mais panorâmica */
     margin: 2rem auto;         /* reduz espaçamento */
     border-radius: 0.5rem;     /* cantos menos arredondados */
     box-shadow: 0 4px 16px rgba(0,0,0,0.06);
@@ -90,14 +89,13 @@
 
   .hero-equipe-image {
     width: 100%;
-    height: 100%;
-    object-fit: cover;
-    object-position: center;    /* centraliza o corte */
+    height: auto;
+    object-fit: contain;
+    object-position: center;
   }
     }
     @media (max-width: 480px) {
   .hero-image {
-    padding-bottom: 56.25%;     /* 16:9 fallback para browsers legados */
     margin: 1.5rem auto;        /* mais compacto */
     border-radius: 0.25rem;
     border: none;               /* sem borda no mobile */
@@ -105,7 +103,7 @@
   }
 
   .hero-equipe-image {
-    object-position: top;       /* foca no topo da imagem */
+    object-fit: contain;
   }
 }
   </style>
@@ -423,7 +421,10 @@
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/>
               </svg>
-             <span>(51) 3710-2935 <br> (51) 98594-0899</span>
+             <span>
+              <a href="tel:+555137102935">(51) 3710-2935</a><br>
+              <a href="tel:+5551985940899">(51) 98594-0899</a>
+            </span>
             </div>
             <div class="contact-item">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -450,13 +451,12 @@
                 <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"/>
               </svg>
             </button>
-            <a class="social-button instagram-link" href="https://www.instagram.com/farmaciapersonallis/" target="_blank" rel="noopener noreferrer">
+            <a class="social-button" href="https://www.instagram.com/farmaciapersonallis/" target="_blank" rel="noopener noreferrer">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <rect x="2" y="2" width="20" height="20" rx="5" ry="5"/>
                 <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"/>
                 <line x1="17.5" y1="6.5" x2="17.51" y2="6.5"/>
               </svg>
-              <span class="instagram-text">Siga-nos</span>
             </a>
             <button class="social-button" onclick="showNotImplemented()">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">

--- a/script.js
+++ b/script.js
@@ -164,6 +164,8 @@ document.addEventListener('DOMContentLoaded', function() {
   addHoverEffects();
   formatPhoneInput();
 
+  showToast('Siga-nos', 'success');
+
   window.scrollToForm = scrollToForm;
   window.showNotImplemented = showNotImplemented;
 

--- a/styles/footer.css
+++ b/styles/footer.css
@@ -57,6 +57,15 @@
   color: var(--gray-300);
 }
 
+.footer-contact .contact-item a {
+  color: var(--gray-300);
+  text-decoration: none;
+}
+
+.footer-contact .contact-item a:hover {
+  text-decoration: underline;
+}
+
 .social-links {
   display: flex;
   gap: 1rem;
@@ -107,17 +116,3 @@
   fill: none !important;
 }
 
-.footer-social .instagram-link {
-  width: auto;
-  padding: 0 0.75rem;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  text-decoration: none;
-  border-radius: 1.25rem;
-}
-
-.footer-social .instagram-text {
-  color: var(--green-300);
-  font-weight: 600;
-}


### PR DESCRIPTION
## Summary
- Replace textual "Siga-nos" link with Instagram icon
- Display green "Siga-nos" toast on page load
- Remove unused Instagram-specific footer styles
- Make footer phone numbers clickable
- Show full team photo on mobile without cropping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7473fa370832ea211b6c02ac672a4