### PR TITLE
Show follow us message only on Instagram click

### DIFF
--- a/index.html
+++ b/index.html
@@ -451,7 +451,7 @@
                 <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"/>
               </svg>
             </button>
-            <a class="social-button" href="https://www.instagram.com/farmaciapersonallis/" target="_blank" rel="noopener noreferrer">
+            <a id="instagram-link" class="social-button" href="https://www.instagram.com/farmaciapersonallis/" target="_blank" rel="noopener noreferrer">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <rect x="2" y="2" width="20" height="20" rx="5" ry="5"/>
                 <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"/>

--- a/script.js
+++ b/script.js
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   function showNotImplemented() {
     showToast(
-      '🚧 Siga-nos!  🚀',
+      '🚧 Recurso não implementado! 🚀',
       'error'
     );
   }
@@ -164,7 +164,12 @@ document.addEventListener('DOMContentLoaded', function() {
   addHoverEffects();
   formatPhoneInput();
 
-  showToast('Siga-nos', 'success');
+  const instagramLink = document.getElementById('instagram-link');
+  if (instagramLink) {
+    instagramLink.addEventListener('click', () => {
+      showToast('Siga-nos', 'success');
+    });
+  }
 
   window.scrollToForm = scrollToForm;
   window.showNotImplemented = showNotImplemented;


### PR DESCRIPTION
## Summary
- Remove automatic "Siga-nos" toast on load and trigger it on Instagram icon click
- Clarify unimplemented social buttons with a new toast message

## Testing
- `npm test` *(fails: ENOENT, missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7497a764c832e87ad0c7983951e6a